### PR TITLE
Show weapon info on attack roll in chat

### DIFF
--- a/src/module/dice.js
+++ b/src/module/dice.js
@@ -184,6 +184,10 @@ export async function rollTest(
     spellTest: testType === 'spell',
     tooltip: await roll.getTooltip(),
   };
+  if (weapon) {
+    templateData.weapon = weapon.toObject(false);
+    templateData.weapon.system.qualities = await ZweihanderQuality.getQualities(weapon.system.qualities.value);
+  }
   if (spell) {
     templateData.itemId = spell.id;
     templateData.spell = spell.toObject(false);

--- a/src/templates/chat/chat-skill.hbs
+++ b/src/templates/chat/chat-skill.hbs
@@ -1,6 +1,8 @@
 <div class="skill-test" data-item-id="{{itemId}}">
 {{#if spellTest}}
   {{> ($$ "item-card/item-card-spell") spell }}
+{{else if weaponTest}}
+  {{> ($$ "item-card/item-card-weapon") weapon }}
 {{else}}
   <h2 class="skill-test-title">{{zhLocalizeConditional "ZWEI.actor.skills." skill}}</h2>
 {{/if}}
@@ -24,7 +26,7 @@
     {{#if usedFortune}}<span class="pill pill-fortune">{{localize "ZWEI.rolls.usefortune"}}</span>{{/if}}
     {{#if usedMisfortune}}<span class="pill pill-misfortune">{{localize "ZWEI.rolls.usemisfortune"}}</span>{{/if}}
     {{#if isReroll}}<span class="pill pill-reroll">{{localize "ZWEI.rolls.reroll"}}</span>{{/if}}
-    {{#if spellTest}}<span class="pill">{{localize "ZWEI.rolls.test"}}: {{zhLocalizeConditional "ZWEI.actor.skills." skill}}</span>{{/if}}
+    {{#if (or spellTest weaponTest)}}<span class="pill">{{localize "ZWEI.rolls.test"}}: {{zhLocalizeConditional "ZWEI.actor.skills." skill}}</span>{{/if}}
 </div>
 <div class="dice-roll">
     <div class="dice-result">


### PR DESCRIPTION
Weapon qualities are especially useful here as they may affect parrying and dodging.
This changes the attack card in chat to show weapon info as can be seen on the right, making it similar to spell cast chat message.

![attack-card-comparison](https://user-images.githubusercontent.com/26313554/233422240-8284e761-66d6-4ff9-b0ca-5f481f54a2c3.jpg)

(please ignore the ids showing at the bottom of the cards - they are displayed by "dev-mode" module)