### PR TITLE
Preliminary work on carrying equipment encumbrance

### DIFF
--- a/src/module/actor/entity/pc.js
+++ b/src/module/actor/entity/pc.js
@@ -70,8 +70,16 @@ export default class ZweihanderPC extends ZweihanderBaseActor {
       });
     }
 
-    // encumbrance calculations...
+    const enc = (systemData.stats.secondaryAttributes.encumbrance = this._calculateEnumberance(actor, configOptions));
+
+    systemData.stats.secondaryAttributes.initiative = this._calculateInitiative(actor, enc, configOptions);
+
+    systemData.stats.secondaryAttributes.movement = this._calculateMovement(actor, enc, configOptions);
+  }
+
+  _calculateEnumberance(actor, configOptions) {
     // assign encumbrance from equipped trappings
+    const systemData = actor.system;
     const carriedTrappings = actor.items.filter(
       (i) => ['trapping', 'armor', 'weapon'].includes(i.type) && i.system.carried
     );
@@ -79,36 +87,45 @@ export default class ZweihanderPC extends ZweihanderBaseActor {
     const smallTrappingsEnc = !nine4one
       ? 0
       : Math.floor(
-          carriedTrappings
-            .filter((t) => t.system.encumbrance === 0)
-            .map((t) => t.system.quantity || 0)
-            .reduce((a, b) => a + b, 0) / 9
-        );
+        carriedTrappings
+          .filter((t) => t.system.encumbrance === 0)
+          .map((t) => t.system.quantity || 0)
+          .reduce((a, b) => a + b, 0) / 9
+      );
     const normalTrappingsEnc = carriedTrappings
       .filter((t) => t.system.encumbrance !== 0)
       .map((t) => t.system.encumbrance * (t.system.quantity ?? 1))
       .reduce((a, b) => a + b, 0);
     // assign encumbrance from currency
     const currencyEnc = Math.floor(Object.values(systemData.currency).reduce((a, b) => a + b, 0) / 1000);
-    const enc = (systemData.stats.secondaryAttributes.encumbrance = {});
+    const enc =  {};
     // assign initial encumbrance threshold
     enc.value = systemData.stats.primaryAttributes.brawn.bonus + 3 + configOptions.encumbranceModifier;
     // assign current encumbrance
     enc.current = smallTrappingsEnc + normalTrappingsEnc + currencyEnc;
     // assign overage
     enc.overage = Math.max(0, enc.current - enc.value);
-    // calculate initiative
-    const ini = (systemData.stats.secondaryAttributes.initiative = {});
+    return enc;
+  }
+
+  _calculateInitiative(actor, enc, configOptions) {
+    const systemData = actor.system;
+    const ini = {};
     ini.value =
       systemData.stats.primaryAttributes[configOptions.intAttribute].bonus + 3 + configOptions.initiativeModifier;
     ini.overage = enc.overage;
     ini.current = Math.max(0, ini.value - ini.overage);
-    // calculate movement
-    const mov = (systemData.stats.secondaryAttributes.movement = {});
+    return ini;
+  }
+
+  _calculateMovement(actor, enc, configOptions) {
+    const systemData = actor.system;
+    const mov = {};
     mov.value =
       systemData.stats.primaryAttributes[configOptions.movAttribute].bonus + 3 + configOptions.movementModifier;
     mov.overage = enc.overage;
     mov.current = Math.max(0, mov.value - mov.overage);
+    return mov;
   }
 
   // parry, dodge & magick depend on Item preparation being finished

--- a/src/module/config.js
+++ b/src/module/config.js
@@ -248,6 +248,8 @@ ZWEI.statusEffects = [
   },
 ];
 
+ZWEI.containerEncumbranceBonus = {};
+
 export { ZWEI };
 
 // this exact if statement guarantees vite will tree-shake this out in prod

--- a/src/module/zweihander.js
+++ b/src/module/zweihander.js
@@ -193,8 +193,29 @@ Hooks.once('init', async function () {
   // Register Helpers
   await registerHandlebarHelpers();
   // Register Templates
-  return preloadHandlebarsTemplates();
+  await preloadHandlebarsTemplates();
+
+  // load carrying item data - temporary solution before proper configuration UI is created
+  CONFIG.ZWEI.containerEncumbranceBonus = await loadContainerEncumbranceData();
 });
+
+async function loadContainerEncumbranceData() {
+  const path = `worlds/${game.world.id}/carrying-items.json`;
+  try {
+    const data = await foundry.utils.fetchJsonWithTimeout(path);
+    return data;
+  }
+  catch (error) {
+    if (error.code === 404) {
+      console.log(`zweihander carrying item encumbrance data not found at ${path}\n` + 
+                  `JSON with mapping from item name to bonus expected`);
+    }
+    else {
+      console.warn(`Error loading carrying item encumbrance data from ${path} : ${error}`);
+    }
+  }
+  return {};
+}
 
 Hooks.on('renderChatMessage', ZweihanderChat.addLocalChatListeners);
 Hooks.on('renderChatLog', (app, html, data) => ZweihanderChat.addGlobalChatListeners(html));


### PR DESCRIPTION
This is the first part part of the implementation of carrying equipment (backpacks, and such) by providing bonus to encumbrance limit (as described in "Carrying equipment", Zweihänder Revised Core Rulebook, p.216).

The PR contains small refactor of the code used for encumbrance, initiative and movement calculations (as the latter two depend on overage), and introduces encumbrance bonus from carrying equipment.

In this version the "capacity"/encumbrance bonus is read from `carrying-items.json` file, if one is present in the current world. The file should contain mapping of item name to bonus. Example:
```json
{
    "Backpack": 3,
    "Rucksack": 2,
    "Gaff Bag": 1,
    "Shoulder Bag": 1
}
```

This version of implementation is meant as **"internal preview"** of the functionality. The second part will follow after agreement on how to provide the bonus data properly (as there are few possible options).